### PR TITLE
[bug fix] 'frompackages' directive functionality seems to be broken when using inheritance

### DIFF
--- a/backtrader/metabase.py
+++ b/backtrader/metabase.py
@@ -276,6 +276,8 @@ class MetaParams(MetaBase):
                 pmod = __import__(p, fromlist=[str(fp)])
                 pattr = getattr(pmod, fp)
                 setattr(clsmod, falias, pattr)
+                for basecls in cls.__bases__:
+                    setattr(sys.modules[basecls.__module__], falias, pattr)
 
         # Create params and set the values from the kwargs
         params = cls.params()

--- a/tests/test_metaclass.py
+++ b/tests/test_metaclass.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2015-2020 Daniel Rodriguez
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+import testcommon
+
+class TestFrompackages(testcommon.SampleParamsHolder):
+    """
+    This class is used for testing that inheriting from base class that
+    uses `frompackages` import mechanism, doesnt brake the functionality
+    of the base class.
+    """
+    def __init__(self):
+        super(TestFrompackages, self).__init__()
+        # Prepare the lags array
+
+def test_run(main=False):
+    """
+    Instantiate the TestFrompackages and see that no exception is raised
+    Bug Discussion:
+    https://community.backtrader.com/topic/2661/frompackages-directive-functionality-seems-to-be-broken-when-using-inheritance
+    """
+    test = TestFrompackages()
+
+if __name__ == '__main__':
+    test_run(main=True)

--- a/tests/testcommon.py
+++ b/tests/testcommon.py
@@ -31,6 +31,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import backtrader as bt
 import backtrader.utils.flushfile
+from backtrader.metabase import ParamsBase
 
 
 modpath = os.path.dirname(os.path.abspath(__file__))
@@ -220,3 +221,17 @@ class TestStrategy(bt.Strategy):
                             assert chkval == linevals[i][0]
                         except AssertionError:
                             assert chkval == linevals[i][1]
+
+
+class SampleParamsHolder(ParamsBase):
+    """
+    This class is used as base for tests that check the proper
+    handling of meta parameters like `frompackages`, `packages`, `params`, `lines`
+    in inherited classes
+    """
+    frompackages = (
+        ('numpy', ('asarray')),
+    )
+
+    def __init__(self):
+        self.range = asarray(range(0, 10))

--- a/tests/testcommon.py
+++ b/tests/testcommon.py
@@ -230,8 +230,8 @@ class SampleParamsHolder(ParamsBase):
     in inherited classes
     """
     frompackages = (
-        ('numpy', ('asarray')),
+        ('math', ('factorial')),
     )
 
     def __init__(self):
-        self.range = asarray(range(0, 10))
+        self.range = factorial(10)


### PR DESCRIPTION
Closes #24 

Community discussion:

https://community.backtrader.com/topic/2661/frompackages-directive-functionality-seems-to-be-broken-when-using-inheritance