### PR TITLE
Adds feature: "candlestick trend" plots

### DIFF
--- a/backtrader/plot/plot.py
+++ b/backtrader/plot/plot.py
@@ -716,7 +716,8 @@ class Plot_OldSync(with_metaclass(MetaParams, object)):
                     label=datalabel,
                     alpha=self.pinf.sch.baralpha,
                     fillup=self.pinf.sch.barupfill,
-                    filldown=self.pinf.sch.bardownfill)
+                    filldown=self.pinf.sch.bardownfill,
+                    trend=self.pinf.sch.trend)
 
             elif self.pinf.sch.style.startswith('bar') or True:
                 # final default option -- should be "else"

--- a/backtrader/plot/scheme.py
+++ b/backtrader/plot/scheme.py
@@ -125,6 +125,9 @@ class PlotScheme(object):
         # Opacity for the filled candlesticks (1.0 opaque - 0.0 transparent)
         self.baralpha = 1.0
 
+        # Whether to implement a candlestick 'trend' plot or not
+        self.trend = False
+
         # Alpha blending for fill areas between lines (_fill_gt and _fill_lt)
         self.fillalpha = 0.20
 


### PR DESCRIPTION
Adds a new boolean plot parameter called "trend" that can be used in conjunction with style='candle' in cerebro.plot. If invoked, the candlestick bars are colored and filled according to the "candlestick trend" definition (i.e. the color of the bar is selected based on the price action between the previous bar and the current bar, and the fill of the bar is selected by the price action of the current bar).

Default behavior: If "trend" parameter is not given, then 'style=candle' will default to the existing backtrader behavior for candlestick plots (i.e. trend=False)