### PR TITLE
Modify ibstore.py to fix #41: IBStore.dt_plus_duration calculates month offset incorrectly

### DIFF
--- a/backtrader/stores/ibstore.py
+++ b/backtrader/stores/ibstore.py
@@ -1187,7 +1187,7 @@ class IBStore(with_metaclass(MetaSingleton, object)):
         if dim == 'M':
             month = dt.month - 1 + size  # -1 to make it 0 based, readd below
             years, month = divmod(month, 12)
-            return dt.replace(year=dt.year + years, month=month + 1)
+            return dt.replace(year=dt.year + years, month=month + 1, day=1) + timedelta(dt.day - 1)
 
         if dim == 'Y':
             return dt.replace(year=dt.year + size)


### PR DESCRIPTION
Hi, 
Just a small modification of ibstore.py to fix https://github.com/backtrader2/backtrader/issues/41
Month offset was done by changing the month number, which caused problem when for ex. the 31th of January was offset to February.
