### PR TITLE
Pandas numeric columns causing .lower errors. Issue #43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
 
 
 # command to install dependencies
-# install:
-#  - pip install your_package
+install:
+  - pip install pandas
 #    pip install git+https://github.com/blampe/IbPy.git
 
 # command to run tests

--- a/backtrader/feeds/pandafeed.py
+++ b/backtrader/feeds/pandafeed.py
@@ -18,8 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ###############################################################################
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from backtrader.utils.py3 import filter, string_types, integer_types
 
@@ -28,7 +27,7 @@ import backtrader.feed as feed
 
 
 class PandasDirectData(feed.DataBase):
-    '''
+    """
     Uses a Pandas DataFrame as the feed source, iterating directly over the
     tuples returned by "itertuples".
 
@@ -42,21 +41,19 @@ class PandasDirectData(feed.DataBase):
       - A negative value in any of the parameters for the Data lines
         indicates it's not present in the DataFrame
         it is
-    '''
+    """
 
     params = (
-        ('datetime', 0),
-        ('open', 1),
-        ('high', 2),
-        ('low', 3),
-        ('close', 4),
-        ('volume', 5),
-        ('openinterest', 6),
+        ("datetime", 0),
+        ("open", 1),
+        ("high", 2),
+        ("low", 3),
+        ("close", 4),
+        ("volume", 5),
+        ("openinterest", 6),
     )
 
-    datafields = [
-        'datetime', 'open', 'high', 'low', 'close', 'volume', 'openinterest'
-    ]
+    datafields = ["datetime", "open", "high", "low", "close", "volume", "openinterest"]
 
     def start(self):
         super(PandasDirectData, self).start()
@@ -72,7 +69,7 @@ class PandasDirectData(feed.DataBase):
 
         # Set the standard datafields - except for datetime
         for datafield in self.getlinealiases():
-            if datafield == 'datetime':
+            if datafield == "datetime":
                 continue
 
             # get the column index
@@ -89,7 +86,7 @@ class PandasDirectData(feed.DataBase):
             line[0] = row[colidx]
 
         # datetime
-        colidx = getattr(self.params, 'datetime')
+        colidx = getattr(self.params, "datetime")
         tstamp = row[colidx]
 
         # convert to float via datetime and store it
@@ -97,7 +94,7 @@ class PandasDirectData(feed.DataBase):
         dtnum = date2num(dt)
 
         # get the line to be set
-        line = getattr(self.lines, 'datetime')
+        line = getattr(self.lines, "datetime")
         line[0] = dtnum
 
         # Done ... return
@@ -105,7 +102,7 @@ class PandasDirectData(feed.DataBase):
 
 
 class PandasData(feed.DataBase):
-    '''
+    """
     Uses a Pandas DataFrame as the feed source, using indices into column
     names (which can be "numeric")
 
@@ -131,34 +128,30 @@ class PandasData(feed.DataBase):
         - None: column not present
         - -1: autodetect
         - >= 0 or string: specific colum identifier
-    '''
+    """
 
     params = (
-        ('nocase', True),
-
+        ("nocase", True),
         # Possible values for datetime (must always be present)
         #  None : datetime is the "index" in the Pandas Dataframe
         #  -1 : autodetect position or case-wise equal name
         #  >= 0 : numeric index to the colum in the pandas dataframe
         #  string : column name (as index) in the pandas dataframe
-        ('datetime', None),
-
+        ("datetime", None),
         # Possible values below:
         #  None : column not present
         #  -1 : autodetect position or case-wise equal name
         #  >= 0 : numeric index to the colum in the pandas dataframe
         #  string : column name (as index) in the pandas dataframe
-        ('open', -1),
-        ('high', -1),
-        ('low', -1),
-        ('close', -1),
-        ('volume', -1),
-        ('openinterest', -1),
+        ("open", -1),
+        ("high", -1),
+        ("low", -1),
+        ("close", -1),
+        ("volume", -1),
+        ("openinterest", -1),
     )
 
-    datafields = [
-        'datetime', 'open', 'high', 'low', 'close', 'volume', 'openinterest'
-    ]
+    datafields = ["datetime", "open", "high", "low", "close", "volume", "openinterest"]
 
     def __init__(self):
         super(PandasData, self).__init__()
@@ -171,35 +164,39 @@ class PandasData(feed.DataBase):
 
         # try to autodetect if all columns are numeric
         cstrings = filter(lambda x: isinstance(x, string_types), colnames)
-        colsnumeric = not len(list(cstrings))
+        self.colsnumeric = not len(list(cstrings))
 
         # Where each datafield find its value
         self._colmapping = dict()
 
-        # Build the column mappings to internal fields in advance
-        for datafield in self.getlinealiases():
-            defmapping = getattr(self.params, datafield)
+        if self.colsnumeric:
+            self._colmapping = dict(zip(self.datafields, [None, 0, 1, 2, 3, 4, 5]))
+        else:
+            # Build the column mappings to internal fields in advance
 
-            if isinstance(defmapping, integer_types) and defmapping < 0:
-                # autodetection requested
-                for colname in colnames:
-                    if isinstance(colname, string_types):
-                        if self.p.nocase:
-                            found = datafield.lower() == colname.lower()
-                        else:
-                            found = datafield == colname
+            for datafield in self.getlinealiases():
+                defmapping = getattr(self.params, datafield)
 
-                        if found:
-                            self._colmapping[datafield] = colname
-                            break
+                if isinstance(defmapping, integer_types) and defmapping < 0:
+                    # autodetection requested
+                    for colname in colnames:
+                        if isinstance(colname, string_types):
+                            if self.p.nocase:
+                                found = datafield.lower() == colname.lower()
+                            else:
+                                found = datafield == colname
 
-                if datafield not in self._colmapping:
-                    # autodetection requested and not found
-                    self._colmapping[datafield] = None
-                    continue
-            else:
-                # all other cases -- used given index
-                self._colmapping[datafield] = defmapping
+                            if found:
+                                self._colmapping[datafield] = colname
+                                break
+
+                    if datafield not in self._colmapping:
+                        # autodetection requested and not found
+                        self._colmapping[datafield] = None
+                        continue
+                else:
+                    # all other cases -- used given index
+                    self._colmapping[datafield] = defmapping
 
     def start(self):
         super(PandasData, self).start()
@@ -208,7 +205,7 @@ class PandasData(feed.DataBase):
         self._idx = -1
 
         # Transform names (valid for .ix) into indices (good for .iloc)
-        if self.p.nocase:
+        if self.p.nocase and not self.colsnumeric:
             colnames = [x.lower() for x in self.p.dataname.columns.values]
         else:
             colnames = [x for x in self.p.dataname.columns.values]
@@ -231,6 +228,7 @@ class PandasData(feed.DataBase):
 
             self._colmapping[k] = v
 
+
     def _load(self):
         self._idx += 1
 
@@ -240,7 +238,7 @@ class PandasData(feed.DataBase):
 
         # Set the standard datafields
         for datafield in self.getlinealiases():
-            if datafield == 'datetime':
+            if datafield == "datetime":
                 continue
 
             colindex = self._colmapping[datafield]
@@ -255,7 +253,7 @@ class PandasData(feed.DataBase):
             line[0] = self.p.dataname.iloc[self._idx, colindex]
 
         # datetime conversion
-        coldtime = self._colmapping['datetime']
+        coldtime = self._colmapping["datetime"]
 
         if coldtime is None:
             # standard index in the datetime

--- a/backtrader/feeds/pandafeed.py
+++ b/backtrader/feeds/pandafeed.py
@@ -170,10 +170,14 @@ class PandasData(feed.DataBase):
         self._colmapping = dict()
 
         if self.colsnumeric:
+            colsextend = [dataname for dataname in self.getlinealiases() if dataname
+            not in self.datafields]
+            ext_idx_start = len(self.datafields) - 1
             self._colmapping = dict(zip(self.datafields, [None, 0, 1, 2, 3, 4, 5]))
+            self._colmapping.update(dict(zip(colsextend, range(ext_idx_start, ext_idx_start + len(
+                colsextend)))))
         else:
             # Build the column mappings to internal fields in advance
-
             for datafield in self.getlinealiases():
                 defmapping = getattr(self.params, datafield)
 

--- a/backtrader/feeds/pandafeed.py
+++ b/backtrader/feeds/pandafeed.py
@@ -18,7 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ###############################################################################
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 from backtrader.utils.py3 import filter, string_types, integer_types
 
@@ -27,7 +28,7 @@ import backtrader.feed as feed
 
 
 class PandasDirectData(feed.DataBase):
-    """
+    '''
     Uses a Pandas DataFrame as the feed source, iterating directly over the
     tuples returned by "itertuples".
 
@@ -41,19 +42,21 @@ class PandasDirectData(feed.DataBase):
       - A negative value in any of the parameters for the Data lines
         indicates it's not present in the DataFrame
         it is
-    """
+    '''
 
     params = (
-        ("datetime", 0),
-        ("open", 1),
-        ("high", 2),
-        ("low", 3),
-        ("close", 4),
-        ("volume", 5),
-        ("openinterest", 6),
+        ('datetime', 0),
+        ('open', 1),
+        ('high', 2),
+        ('low', 3),
+        ('close', 4),
+        ('volume', 5),
+        ('openinterest', 6),
     )
 
-    datafields = ["datetime", "open", "high", "low", "close", "volume", "openinterest"]
+    datafields = [
+        'datetime', 'open', 'high', 'low', 'close', 'volume', 'openinterest'
+    ]
 
     def start(self):
         super(PandasDirectData, self).start()
@@ -69,7 +72,7 @@ class PandasDirectData(feed.DataBase):
 
         # Set the standard datafields - except for datetime
         for datafield in self.getlinealiases():
-            if datafield == "datetime":
+            if datafield == 'datetime':
                 continue
 
             # get the column index
@@ -86,7 +89,7 @@ class PandasDirectData(feed.DataBase):
             line[0] = row[colidx]
 
         # datetime
-        colidx = getattr(self.params, "datetime")
+        colidx = getattr(self.params, 'datetime')
         tstamp = row[colidx]
 
         # convert to float via datetime and store it
@@ -94,7 +97,7 @@ class PandasDirectData(feed.DataBase):
         dtnum = date2num(dt)
 
         # get the line to be set
-        line = getattr(self.lines, "datetime")
+        line = getattr(self.lines, 'datetime')
         line[0] = dtnum
 
         # Done ... return
@@ -102,7 +105,7 @@ class PandasDirectData(feed.DataBase):
 
 
 class PandasData(feed.DataBase):
-    """
+    '''
     Uses a Pandas DataFrame as the feed source, using indices into column
     names (which can be "numeric")
 
@@ -128,30 +131,34 @@ class PandasData(feed.DataBase):
         - None: column not present
         - -1: autodetect
         - >= 0 or string: specific colum identifier
-    """
+    '''
 
     params = (
-        ("nocase", True),
+        ('nocase', True),
+
         # Possible values for datetime (must always be present)
         #  None : datetime is the "index" in the Pandas Dataframe
         #  -1 : autodetect position or case-wise equal name
         #  >= 0 : numeric index to the colum in the pandas dataframe
         #  string : column name (as index) in the pandas dataframe
-        ("datetime", None),
+        ('datetime', None),
+
         # Possible values below:
         #  None : column not present
         #  -1 : autodetect position or case-wise equal name
         #  >= 0 : numeric index to the colum in the pandas dataframe
         #  string : column name (as index) in the pandas dataframe
-        ("open", -1),
-        ("high", -1),
-        ("low", -1),
-        ("close", -1),
-        ("volume", -1),
-        ("openinterest", -1),
+        ('open', -1),
+        ('high', -1),
+        ('low', -1),
+        ('close', -1),
+        ('volume', -1),
+        ('openinterest', -1),
     )
 
-    datafields = ["datetime", "open", "high", "low", "close", "volume", "openinterest"]
+    datafields = [
+        'datetime', 'open', 'high', 'low', 'close', 'volume', 'openinterest'
+    ]
 
     def __init__(self):
         super(PandasData, self).__init__()
@@ -232,7 +239,6 @@ class PandasData(feed.DataBase):
 
             self._colmapping[k] = v
 
-
     def _load(self):
         self._idx += 1
 
@@ -242,7 +248,7 @@ class PandasData(feed.DataBase):
 
         # Set the standard datafields
         for datafield in self.getlinealiases():
-            if datafield == "datetime":
+            if datafield == 'datetime':
                 continue
 
             colindex = self._colmapping[datafield]
@@ -257,7 +263,7 @@ class PandasData(feed.DataBase):
             line[0] = self.p.dataname.iloc[self._idx, colindex]
 
         # datetime conversion
-        coldtime = self._colmapping["datetime"]
+        coldtime = self._colmapping['datetime']
 
         if coldtime is None:
             # standard index in the datetime

--- a/tests/test_data_pandas.py
+++ b/tests/test_data_pandas.py
@@ -25,7 +25,6 @@ import datetime
 import os
 import testcommon
 
-import backtrader as bt
 from backtrader import feeds as btfeeds
 import backtrader.indicators as btind
 import pandas
@@ -58,7 +57,7 @@ class PandasDataOptix(btfeeds.PandasData):
               ('optix_opt', -1))
 
 
-def getdata(index, noheaders=True, nocase=True):
+def getdata(index, noheaders=True):
 
     datapath = os.path.join(modpath, dataspath, datafiles[index])
 
@@ -73,20 +72,19 @@ def getdata(index, noheaders=True, nocase=True):
                                 index_col=0)
 
     # Pass it to the backtrader datafeed and add it to the cerebro
+    # Data in upper case for headers, nocase=True.
     if index:
-        data = PandasDataOptix(dataname=dataframe, nocase=nocase)
+        data = PandasDataOptix(dataname=dataframe, nocase=True)
     else:
-        data = bt.feeds.PandasData(dataname=dataframe, nocase=nocase)
+        data = btfeeds.PandasData(dataname=dataframe, nocase=True)
     return data
 
 def test_run(main=False):
     # Create list with bool possibilitys for:
     # PandasData and PandasOptix,
     # no headers,
-    # no case.
     dc = [0, 1]
-    data = [getdata(i, noheaders=nh, nocase=nc) for i in dc for nh in dc for nc in dc]
-    data = testcommon.getdata(0)
+    data = [getdata(i, noheaders=nh) for i in dc for nh in dc]
 
     for runonce in [True, False]:
         datas = data

--- a/tests/test_data_pandas.py
+++ b/tests/test_data_pandas.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2015-2020 Daniel Rodriguez
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import datetime
+import os
+import testcommon
+
+import backtrader as bt
+from backtrader import feeds as btfeeds
+import backtrader.indicators as btind
+import pandas
+
+chkdatas = 1
+chkvals = [
+    ['4063.463000', '3644.444667', '3554.693333']
+]
+
+chkmin = 30  # period will be in weeks
+chkind = [btind.SMA]
+chkargs = dict()
+
+modpath = os.path.dirname(os.path.abspath(__file__))
+dataspath = '../datas'
+datafiles = [
+    '2006-day-001.txt',
+    '2006-day-001-optix.txt',
+]
+
+FROMDATE = datetime.datetime(2006, 1, 1)
+TODATE = datetime.datetime(2006, 12, 31)
+
+
+class PandasDataOptix(btfeeds.PandasData):
+
+    lines = ('optix_close', 'optix_pess', 'optix_opt',)
+    params = (('optix_close', -1),
+              ('optix_pess', -1),
+              ('optix_opt', -1))
+
+
+def getdata(index, noheaders=True, nocase=True):
+
+    datapath = os.path.join(modpath, dataspath, datafiles[index])
+
+    # Simulate the header row isn't there if noheaders requested
+    skiprows = 1 if noheaders else 0
+    header = None if noheaders else 0
+
+    dataframe = pandas.read_csv(datapath,
+                                skiprows=skiprows,
+                                header=header,
+                                parse_dates=True,
+                                index_col=0)
+
+    # Pass it to the backtrader datafeed and add it to the cerebro
+    if index:
+        data = PandasDataOptix(dataname=dataframe, nocase=nocase)
+    else:
+        data = bt.feeds.PandasData(dataname=dataframe, nocase=nocase)
+    return data
+
+def test_run(main=False):
+    # Create list with bool possibilitys for:
+    # PandasData and PandasOptix,
+    # no headers,
+    # no case.
+    dc = [0, 1]
+    data = [getdata(i, noheaders=nh, nocase=nc) for i in dc for nh in dc for nc in dc]
+    data = testcommon.getdata(0)
+
+    for runonce in [True, False]:
+        datas = data
+        testcommon.runtest(datas,
+                           testcommon.TestStrategy,
+                           main=main,
+                           runonce=runonce,
+                           plot=False,
+                           chkind=chkind,
+                           chkmin=chkmin,
+                           chkvals=chkvals,
+                           chkargs=chkargs)
+
+
+if __name__ == '__main__':
+    test_run(main=True)


### PR DESCRIPTION
In 2017 the numeric check was dropped from the code. However, the function (colsnumeric) for checking if the dataframe headers were numeric and not string was still in the code. But there was no use of this function any longer. 

Consequently, the current workflow sees the numeric headers not being properly identified and heading into the section where the text headers get sorted and identified. The numeric headers hits a x.lower() designed for strings and an error is thrown, hence this issue.

I have reinstated now the use of the `colsnumeric`.  I have added back in similar fashion (but not exactly the same) code that will set the `self._colmapping` dict which gets used when iterating through the pandas lines to create the backtrader lines.

The order of the columns is obviously important since there is no text to determine the lines. I have checked the [historical codes](https://github.com/mementum/backtrader/commit/05051890efe527ee22919d354038b4dfc1ffe7ca#diff-367c56de63ec5ee081bbbee8f66b1718aecbd507187b4fa39a44398dcb7ad9c5) as well as the [docs](https://www.backtrader.com/docu/pandas-datafeed/pandas-datafeed/) and set the columns accordingly:

{'datetime': None, 'open': 0, 'high': 1, 'low': 2, 'close': 3, 'volume': 4, 'openinterest': 5}

`datetime` being index of the dataframe. 

The `self.colsnumeric` bool qualifier is carried forward and used in the Transform names section in `start()`. This will ensure that numeric headers skip the `.lower()` error and use the second conditional in

```
# Transform names (valid for .ix) into indices (good for .iloc)
        if self.p.nocase and not self.colsnumeric:
            colnames = [x.lower() for x in self.p.dataname.columns.values]
        else:
            colnames = [x for x in self.p.dataname]
```

I will create some test cases but this is working so far. I have run this with numeric and text headers. 