### PR TITLE
test files for PR #55 : travis.yml & test_stores_ibstore_dt+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ matrix:
 
 
 # command to install dependencies
-# install:
-#  - pip install your_package
-#    pip install git+https://github.com/blampe/IbPy.git
+install:
+  - pip install git+https://github.com/blampe/IbPy.git
+# - pip install your_package
+
 
 # command to run tests
 script: cd tests && nosetests -v -v

--- a/tests/test_stores_ibstore_dt_plus_duration.py
+++ b/tests/test_stores_ibstore_dt_plus_duration.py
@@ -1,0 +1,26 @@
+import backtrader as bt
+import datetime as dt
+
+store = bt.stores.IBStore()
+
+
+def test_run():
+
+    test_cases = [
+                (dt.datetime(2020, 7, 31), '2 M', dt.datetime(2020, 10, 1)),
+                (dt.datetime(2020, 12, 29), '2 M', dt.datetime(2021, 3, 1)),
+                (dt.datetime(2020, 12, 30), '2 M', dt.datetime(2021, 3, 2)),
+                (dt.datetime(2020, 12, 31), '2 M', dt.datetime(2021, 3, 3)),
+                (dt.datetime(2019, 12, 29), '2 M', dt.datetime(2020, 2, 29)),
+                (dt.datetime(2019, 12, 30), '2 M', dt.datetime(2020, 3, 1)),
+                (dt.datetime(2019, 12, 31), '2 M', dt.datetime(2020, 3, 2)),
+                (dt.datetime(1999, 12, 31), '2 M', dt.datetime(2000, 3, 2)),
+                (dt.datetime(2099, 12, 31), '2 M', dt.datetime(2100, 3, 3))
+                ]
+    for src_dt, duration_str, trg_dt in test_cases:
+        calculated_dt = store.dt_plus_duration(src_dt, duration_str)
+        assert calculated_dt == trg_dt
+
+
+if __name__ == '__main__':
+    test_run()


### PR DESCRIPTION
Following PR #55 : addition of a test for function dt_plus_duration in ibstore.py. 
Modification of travis.yml to install IbPy2, which is needed in related BT modules.