### PR TITLE
fix issue #33 : from pandas ols_beta to statsmodels ols_beta

### DIFF
--- a/backtrader/indicators/ols.py
+++ b/backtrader/indicators/ols.py
@@ -80,14 +80,15 @@ class OLS_TransformationN(PeriodN):
 
 class OLS_BetaN(PeriodN):
     '''
-    Calculates a regression of data1 on data0 using ``pandas.ols``
+    Calculates a regression of data1 on data0 using ``statsmodels.api.ols``
 
-    Uses ``pandas``
+    Uses ``pandas`` and ``statsmodels``
     '''
     _mindatas = 2  # ensure at least 2 data feeds are passed
 
     packages = (
         ('pandas', 'pd'),
+        ('statsmodels.api', 'smapi'),
     )
 
     lines = ('beta',)
@@ -95,9 +96,10 @@ class OLS_BetaN(PeriodN):
 
     def next(self):
         y, x = (pd.Series(d.get(size=self.p.period)) for d in self.datas)
-        r_beta = pd.ols(y=y, x=x, window_type='full_sample')
-        self.lines.beta[0] = r_beta.beta['x']
-
+        x = smapi.add_constant(x, prepend = True)
+        x.columns=('const', 'x')
+        r_beta = smapi.OLS(y,x).fit()
+        self.lines.beta[0] = r_beta.params['x']
 
 class CointN(PeriodN):
     '''

--- a/tests/test_ind_ols.py
+++ b/tests/test_ind_ols.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; py-indent-offset:4 -*-
+###############################################################################
+#
+# Copyright (C) 2015-2020 Daniel Rodriguez
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import datetime
+import os
+
+import testcommon
+
+import backtrader as bt
+import backtrader.indicators as btind
+import pandas as pd
+
+datafiles = ['orcl-2003-2005.txt', 'yhoo-2003-2005.txt']
+
+chkvals = [
+    ['0.124001', '1.682931', '0.146236'],
+]
+
+chkmin = 10
+chkind = btind.OLS_BetaN
+#chkargs = dict()
+
+DATAFEED = bt.feeds.BacktraderCSVData
+FROMDATE = datetime.datetime(2003, 1, 1)
+TODATE = datetime.datetime(2005, 12, 31)
+
+def getdata(datafile, fromdate=FROMDATE, todate=TODATE):
+    modpath = os.path.dirname(os.path.abspath(__file__))
+    dataspath = '../datas'
+    datapath = os.path.join(modpath, dataspath, datafile)
+    data = DATAFEED(
+        dataname=datapath,
+        fromdate=fromdate,
+        todate=todate)
+
+    return data
+
+class TS2(testcommon.TestStrategy):
+    def __init__(self):
+        ind0 = self.data0.close
+        ind1 = self.data1.close
+        self.p.inddata = [ind0, ind1]
+        self.ind = btind.OLS_BetaN(*self.p.inddata )
+
+def test_run(main=False):
+    datas = [getdata(i) for i in datafiles]
+    testcommon.runtest(datas,
+                       TS2,
+                       main=main,
+                       plot=main,
+                       chkind=chkind,
+                       chkmin=chkmin,
+                       chkvals=chkvals)
+
+
+if __name__ == '__main__':
+    test_run(main=True)


### PR DESCRIPTION
Modification of ols.py indicator,  class OLS_BetaN to switch from pandas ols, which no longer exist in last versions of pandas,  to statsmodels ols.
Addition of a file for test of modified OLS_BetaN class.

