### PR TITLE
Yahoo fix as recommended in pull request [453]

### DIFF
--- a/backtrader/feeds/yahoo.py
+++ b/backtrader/feeds/yahoo.py
@@ -268,6 +268,7 @@ class YahooFinanceData(YahooFinanceCSVData):
 
         crumb = None
         sess = requests.Session()
+        sess.headers['User-Agent'] = 'backtrader'
         for i in range(self.p.retries + 1):  # at least once
             resp = sess.get(url, **sesskwargs)
             if resp.status_code != requests.codes.ok:


### PR DESCRIPTION
Fix recommended by [frruit](https://github.com/frruit) in pull request [453](https://github.com/mementum/backtrader/pull/453/) at backtrader.  

Yahoo feed has stopped working with a `filenotfound` error. This fix corrects that.