### PR TITLE
Fixed MetaLinePlotterIndicator

### DIFF
--- a/backtrader/indicator.py
+++ b/backtrader/indicator.py
@@ -141,8 +141,7 @@ class MtLinePlotterIndicator(Indicator.__class__):
         lname = kwargs.pop('name')
         name = cls.__name__
 
-        lines = getattr(cls, 'lines', Lines)
-        cls.lines = lines._derive(name, (lname,), 0, [])
+        cls.lines = Lines._derive(name, (lname,), 0, [])
 
         plotlines = AutoInfoClass
         newplotlines = dict()


### PR DESCRIPTION
The indicator should not derive its lines from cls but should derive them from proto lines. This fixes using more than one line plotter indicator. After the first indicator, indicators contain lines from previous indicators.

see also https://github.com/backtrader2/backtrader/issues/34 for examples