### PR TITLE
Added enhancement support for Inverse Perpetual Contract and Truncation Precision in backtrader/comminfo.py

### DIFF
--- a/backtrader/cerebro.py
+++ b/backtrader/cerebro.py
@@ -25,6 +25,7 @@ import datetime
 import collections
 import itertools
 import multiprocessing
+import gc
 
 import backtrader as bt
 from .utils.py3 import (map, range, zip, with_metaclass, string_types,
@@ -1144,6 +1145,10 @@ class Cerebro(with_metaclass(MetaParams, object)):
                 self.runstrats.append(r)
                 for cb in self.optcbs:
                     cb(r)  # callback receives finished strategy
+                    # Force GC to run
+                    gc.collect()
+                # Force GC to run
+                gc.collect()
 
             pool.close()
 

--- a/backtrader/feeds/csvgeneric.py
+++ b/backtrader/feeds/csvgeneric.py
@@ -88,17 +88,16 @@ class GenericCSVData(feed.CSVDataBase):
         super(GenericCSVData, self).start()
 
         self._dtstr = False
-        if isinstance(self.p.dtformat, string_types):
-            self._dtstr = True
-        elif isinstance(self.p.dtformat, integer_types):
-            idt = int(self.p.dtformat)
-            if idt == 1:
-                self._dtconvert = lambda x: datetime.utcfromtimestamp(int(x))
-            elif idt == 2:
-                self._dtconvert = lambda x: datetime.utcfromtimestamp(float(x))
-
-        else:  # assume callable
-            self._dtconvert = self.p.dtformat
+        #if isinstance(self.p.dtformat, string_types):
+        #    self._dtstr = True
+        #elif isinstance(self.p.dtformat, integer_types):
+        #    idt = int(self.p.dtformat)
+        #    if idt == 1:
+        #        self._dtconvert = lambda x: datetime.utcfromtimestamp(int(x))
+        #    elif idt == 2:
+        #        self._dtconvert = lambda x: datetime.utcfromtimestamp(float(x))
+        #else:  # assume callable
+        #    self._dtconvert = self.p.dtformat
 
     def _loadline(self, linetokens):
         # Datetime needs special treatment
@@ -113,7 +112,8 @@ class GenericCSVData(feed.CSVDataBase):
 
             dt = datetime.strptime(dtfield, dtformat)
         else:
-            dt = self._dtconvert(dtfield)
+            #dt = self._dtconvert(dtfield)
+            dt = datetime.utcfromtimestamp(int(dtfield[:-3]))
 
         if self.p.timeframe >= TimeFrame.Days:
             # check if the expected end of session is larger than parsed


### PR DESCRIPTION
Hi Admin,

Background: When I was trying to enable Inverse Perpetual Contract for cryptocurrency, it has been discovered that the formula to calculate size, value and commission are inversed of the regular contract. Hence I've decided to invest time to bring up support for Inverse Perpetual Contract. You may find the mentioned backtrader/comminfo.py changes @ **61882ae** but leave the other two commits as it is (as they are meant for my local use).

**61882ae** changes have been tested in my development environment where user could run Backtrader with Inverse Perpetual Contract in cryptocurrency and return the result with proper precision matching with need of cryptocurrency exchanges. The added precision constraint will not affect other instruments such as stocks and future products.

I hope you would consider to pick up **61882ae** changes.