### PR TITLE
Add deep clone to make order clone more secure

### DIFF
--- a/backtrader/order.py
+++ b/backtrader/order.py
@@ -384,12 +384,14 @@ class OrderBase(with_metaclass(MetaParams, object)):
         else:
             self.dteos = 0.0
 
-    def clone(self):
+    def clone(self, deep=True):
         # status, triggered and executed are the only moving parts in order
         # status and triggered are covered by copy
         # executed has to be replaced with an intelligent clone of itself
         obj = copy(self)
         obj.executed = self.executed.clone()
+        if deep:
+            obj.info = self.info.copy()
         return obj  # status could change in next to completed
 
     def getstatusname(self, status=None):


### PR DESCRIPTION
**Issues**
My strategy has a situation I have to clone old order, then I add some info to new cloned order.
But I get error that info object shared between old order and new order.
Whenever I add data to new order info will exist in old order.

**Solution**
I add flag `deep=True` to `order.clone()` function to clone order info whenever call `clone()` function